### PR TITLE
Security/snyk vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Security
 
+## [1.2.10]
+### Changed
+- Upgrade to Quarkus 3.16.4
+- Upgrade Container base image to registry.redhat.io/ubi9/openjdk-21:1.21-3
+
 ## [1.2.9]
 ### Changed
 - Upgrade to Quarkus 3.16.2

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.16.2</quarkus.platform.version>
+    <quarkus.platform.version>3.16.4</quarkus.platform.version>
     <skipITs>true</skipITs>
     <sonar.coverage.jacoco.xmlReportPaths>target/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.dontesta.eventbus</groupId>
   <artifactId>eventbus-logging-filter-jaxrs</artifactId>
-  <version>1.2.9</version>
+  <version>1.2.10</version>
   <name>eventbus-logging-filter-jaxrs</name>
   <description>Event Bus Logging Filter JAX-RS</description>
   <url>https://amusarra.github.io/eventbus-logging-filter-jaxrs-docs</url>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.18-3
+FROM registry.redhat.io/ubi9/openjdk-21:1.21-3
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile.legacy-jar
+++ b/src/main/docker/Dockerfile.legacy-jar
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.18-3
+FROM registry.redhat.io/ubi9/openjdk-21:1.21-3
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
- Upgrade to Quarkus 3.16.4
- Upgrade Container base image to registry.redhat.io/ubi9/openjdk-21:1.21-3