### PR TITLE
Release/1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Security
 
+## [1.3.0] - 2025-06-03
+### Changed
+- Upgrade to Quarkus 3.23.0. See the migration guide at https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.23 (PR #8)
+- Translate the README.md file to English (PR #10)
+
+### Fixed
+- Unable to resolve download URL for '22-ea' (PR #9) on the GitHub Actions workflow
+- Replace deprecated `quarkus.hibernate-orm.database.generation` with `quarkus.hibernate-orm.schema-management.strategy`
+
 ## [1.2.13] - 2025-03-25
 ### Changed
 - Upgrade to Quarkus 3.19.4. See the migration guide at https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.19

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.dontesta.eventbus</groupId>
   <artifactId>eventbus-logging-filter-jaxrs</artifactId>
-  <version>1.2.13</version>
+  <version>1.2.14-SNAPSHOT</version>
   <name>eventbus-logging-filter-jaxrs</name>
   <description>Event Bus Logging Filter JAX-RS</description>
   <url>https://amusarra.github.io/eventbus-logging-filter-jaxrs-docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.dontesta.eventbus</groupId>
   <artifactId>eventbus-logging-filter-jaxrs</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>eventbus-logging-filter-jaxrs</name>
   <description>Event Bus Logging Filter JAX-RS</description>
   <url>https://amusarra.github.io/eventbus-logging-filter-jaxrs-docs</url>
@@ -36,7 +36,7 @@
     <connection>scm:git:git@github.com:amusarra/eventbus-logging-filter-jaxrs.git</connection>
     <developerConnection>scm:git:git@github.com:amusarra/eventbus-logging-filter-jaxrs.git</developerConnection>
     <url>scm:git:git@github.com:amusarra/eventbus-logging-filter-jaxrs.git</url>
-    <tag>v1.3.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <properties>
     <asciidoclet.version>2.0.0</asciidoclet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.dontesta.eventbus</groupId>
   <artifactId>eventbus-logging-filter-jaxrs</artifactId>
-  <version>1.2.14-SNAPSHOT</version>
+  <version>1.3.0</version>
   <name>eventbus-logging-filter-jaxrs</name>
   <description>Event Bus Logging Filter JAX-RS</description>
   <url>https://amusarra.github.io/eventbus-logging-filter-jaxrs-docs</url>
@@ -37,6 +36,7 @@
     <connection>scm:git:git@github.com:amusarra/eventbus-logging-filter-jaxrs.git</connection>
     <developerConnection>scm:git:git@github.com:amusarra/eventbus-logging-filter-jaxrs.git</developerConnection>
     <url>scm:git:git@github.com:amusarra/eventbus-logging-filter-jaxrs.git</url>
+    <tag>v1.3.0</tag>
   </scm>
   <properties>
     <asciidoclet.version>2.0.0</asciidoclet.version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -121,7 +121,7 @@ quarkus.datasource.metrics.enabled=true
 ##
 ## This section configure the Hibernate ORM extension
 ##
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=load_data.sql
 


### PR DESCRIPTION
## [1.3.0] - 2025-06-03
### Changed
- Upgrade to Quarkus 3.23.0. See the migration guide at https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.23 (PR #8)
- Translate the README.md file to English (PR #10)

### Fixed
- Unable to resolve download URL for '22-ea' (PR #9) on the GitHub Actions workflow
- Replace deprecated `quarkus.hibernate-orm.database.generation` with `quarkus.hibernate-orm.schema-management.strategy`